### PR TITLE
[4.5] Move versions into hivemq-platform project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ repositories {
 dependencies {
 
     /* HiveMQ platform constraints */
-    internalPlatform(platform("com.hivemq:hivemq-platform:$version"))
+    internalPlatform(platform("com.hivemq:hivemq-main-platform"))
 
     api("com.hivemq:hivemq-extension-sdk:$version")
     api("org.slf4j:slf4j-api")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,13 +61,30 @@ metadata {
 
 /* ******************** dependencies ******************** */
 
+val internalPlatform by configurations.creating {
+    isVisible = false
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+
+configurations {
+    compileClasspath.get().extendsFrom(internalPlatform)
+    runtimeClasspath.get().extendsFrom(internalPlatform)
+    testCompileClasspath.get().extendsFrom(internalPlatform)
+    testRuntimeClasspath.get().extendsFrom(internalPlatform)
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
+
+    /* HiveMQ platform constraints */
+    internalPlatform(platform("com.hivemq:hivemq-platform:$version"))
+
     api("com.hivemq:hivemq-extension-sdk:$version")
-    api("org.slf4j:slf4j-api:${property("slf4j.version")}")
+    api("org.slf4j:slf4j-api")
 }
 
 
@@ -114,6 +131,15 @@ publishing {
     publications {
         register<MavenPublication>("maven") {
             from(components["java"])
+
+            versionMapping {
+                usage("java-api") {
+                    fromResolutionResult()
+                }
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,5 @@
 version=4.5.5-SNAPSHOT
 #
-# main dependencies
-#
-slf4j.version=1.7.30
-#
 # plugins
 #
 plugin.license.version=0.15.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,6 @@ pluginManagement {
 if (file("../hivemq-extension-sdk").exists()) {
     includeBuild("../hivemq-extension-sdk")
 }
+if (file("../hivemq-platform").exists()) {
+    includeBuild("../hivemq-platform")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,5 @@ pluginManagement {
 if (file("../hivemq-extension-sdk").exists()) {
     includeBuild("../hivemq-extension-sdk")
 }
-if (file("../hivemq-platform").exists()) {
-    includeBuild("../hivemq-platform")
-}
+
+includeBuild("../hivemq-platform")


### PR DESCRIPTION
To make our dependency-update process more comfortable, we decided
to move all the dependency versions into the repository hivemq-platform,
which is a gradle project defining version-constraints for all
dependencies.

From this commit onwards this project will only work, if the
hivemq-platform repository is checked out in the same folder.

Resolves 1756