### PR TITLE
PTE-372: Remove githubPush trigger from CompositeJenkinsfile

### DIFF
--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -7,9 +7,6 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '10'))
         timestamps()
     }
-    triggers {
-        githubPush()
-    }
     stages {
         stage('Trigger build') {
             steps {


### PR DESCRIPTION
Removes the githubPush() trigger from the CompositeJenkinsfile so that pushes to this repository no longer trigger the composite Jenkins pipeline directly.